### PR TITLE
Configuration as command line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.swp
+*.swo
+cert-check

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All other arguments are considered sites to be checked.
 
 Easy to run if the go system is installed:
 ```sh
-go run cert-check.go
+go run check-cert.go okta.okta.com:443
 ```
 
 You can also precompile it for a specific architecture and run cert-check

--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ http://www.theguardian.com/technology/2015/nov/12/apple-user-anger-mac-apps-brea
 
 ## Configuring
 
-Right now, everything is hardcoded. You probably want to change the
-list of sites it checks and how many days before it warns you.
+~~Right now, everything is hardcoded. You probably want to change the
+list of sites it checks and how many days before it warns you.~~
+
+Good news!  cert-check now supports command line arguments.  The
+-notify argument reports any site below that threshold in days.
+All other arguments are considered sites to be checked.
 
 ## Running
 

--- a/check-cert.go
+++ b/check-cert.go
@@ -2,30 +2,39 @@ package main
 
 import (
 	"crypto/tls"
+	"flag"
 	"fmt"
 	"log"
 	"time"
 )
 
-const notify int64 = 220
+type SiteCheck struct {
+	notify int64
+	sites []string
+}
 
 func main() {
-	sites := []string{
-		"okta.okta.com:443",
-		"authbank.com:443",
-		"uber.com:443",
-	}
+	check := new(SiteCheck)
+	parseArguments( check )
 
 	config := tls.Config{InsecureSkipVerify: false}
-	for _, site := range sites {
-		dosite(site, config)
+	for _, site := range check.sites {
+		dosite(site, check.notify, config)
 	}
 }
-func dosite(site string, config tls.Config) {
+
+func parseArguments( check *SiteCheck ) {
+	flag.Int64Var( &check.notify, "notify", 220, "Notify if fewer than this number of days are presented" )
+	flag.Parse()
+	check.sites = flag.Args()
+}
+
+func dosite(site string, notify int64,  config tls.Config) {
 	conn, err := tls.Dial("tcp", site, &config)
 	if err != nil {
-		log.Fatalf("client: %s", err)
+		log.Fatalf("client(%s): %s", site, err)
 	}
+
 	defer conn.Close()
 	state := conn.ConnectionState()
 	for pos, cert := range state.PeerCertificates {
@@ -33,12 +42,15 @@ func dosite(site string, config tls.Config) {
 			diff := cert.NotAfter.Unix() - time.Now().Unix()
 			diff /= 86400
 			certkind := "Certificate"
+
 			if pos > 0 {
 				certkind = "Certificate authority"
 			}
+
 			if diff < notify {
 				fmt.Printf("%s %s expires in %d days at %s (warning at %d days)\n", site, certkind, diff, cert.NotAfter, notify)
 			}
+
 		}
 	}
 }


### PR DESCRIPTION
Adds the notify option to specify reporting threshold, and uses all remaining arguments as sites to check.
